### PR TITLE
GPIOD support for gpiochip0 and gpiochip4

### DIFF
--- a/src/pilomargpio.py
+++ b/src/pilomargpio.py
@@ -21,15 +21,20 @@ try:
     import RPi.GPIO as GPIO # Handling IO signals. If available.
     GPIO.setmode(GPIO.BCM)
     GPIO_DRIVER = "GPIO"
-except: 
+except: # No support for RPi.GPIO detected.
     pass
 
 try:
     import gpiod # Handling IO signals. If available.
-    GPIOchip = gpiod.Chip('gpiochip4')        
     GPIO_DRIVER = "GPIOD"
-except:
+except: # No support for GPIOD detected.
     pass
+
+if GPIO_DRIVER == 'GPIOD': # Select the GPIO handling chip.
+    try:
+        GPIOchip = gpiod.Chip('gpiochip4') # In very early RPi5 Bookworm builds the GPIO chip is 'gpiochip4'.
+    except:
+        GPIOchip = gpiod.Chip('gpiochip0') # In later RPi5 Bookworm builds the GPIO chip is 'gpiochip0'.
 
 def cleanup_gpio():
     """ Perform cleanup at end of session. """


### PR DESCRIPTION
On RPi5 Bookworm recent builds the GPIOD library can fail if the O/S has assigned the GPIO chip to 'gpiochip0' instead of the original 'gpiochip4'. If 'gpiochip4' fails, this will fall back to 'gpiochip0'.